### PR TITLE
build(v7.8): Jupiter test discovery + node-gradle 7.x guard + coherent test gate (mx78 promotions)

### DIFF
--- a/gradle/tagit-angular.gradle
+++ b/gradle/tagit-angular.gradle
@@ -3,6 +3,22 @@ println "[tagit-angular] Applying TagitCore v7.8 WAR and Node JS plug-ins and co
 apply plugin: 'war'
 apply plugin: 'com.github.node-gradle.node'
 
+// [rj.added 2026-07-06] Fail-fast guard: this script requires the node-gradle 7.x node{} DSL (nodeProjectDir,
+// yarn removed, npmInstall.args via tasks.named). node-gradle < 7.x (the old default 2.2.4) uses Gradle APIs
+// removed in Gradle 9 (Project.exec()), so npmSetup fails with a confusing error; and the 7.x-only
+// `nodeProjectDir` used below would throw MissingPropertyException. Detect the 7.x DSL by the presence of the
+// NodeExtension `nodeProjectDir` property. hasProperty(...) is exception-safe (returns a MetaProperty or null),
+// and we only fail on DEFINITIVE old-plugin detection (extension present but no nodeProjectDir) — never on an
+// inconclusive result — so this guard can never break a valid 7.x build.
+def nodeExt = project.extensions.findByName('node')
+if (nodeExt != null && nodeExt.hasProperty('nodeProjectDir') == null) {
+	throw new GradleException(
+		"[tagit-angular] node-gradle plugin >= 7.x is required on the v7.8 (Gradle 9) line, but the applied " +
+		"'com.github.node-gradle.node' plugin does not expose the 7.x node{} DSL (no 'nodeProjectDir'). You are " +
+		"likely on the old default (2.2.4), whose npmSetup uses Project.exec() (removed in Gradle 9) and will " +
+		"fail. Fix: set nodeGradleVersion to >= 7.1.0 for this project (the tagit-core connectors use 7.1.0).")
+}
+
 def getDate() {
     return new Date().format('yyyyMMddHHmmss')
 }

--- a/gradle/tagit-sonar.gradle
+++ b/gradle/tagit-sonar.gradle
@@ -20,8 +20,16 @@ tasks.withType(Test).configureEach {
 
     ignoreFailures = true
 
-	// Ensure JUnit Tests does not run by default, but must be included explicitly, i.e. `gradlew test`
-    onlyIf { gradle.startParameter.taskNames.contains('test') }
+	// [rj.changed 2026-07-06] The "one true way" test gate (mx78 Promotion 3, Option A). Tests now run BY
+	// DEFAULT (standard Gradle: `build` depends on `test`) and are skipped ON DEMAND with `-Dskip.tests=true`.
+	// This replaces the previous `taskNames.contains('test')` gate, which silently skipped tests on `gradlew
+	// build` (a green build that validated nothing — how the SF7 dispatch regression shipped). It also removes
+	// the per-consumer INVERTED `test.onlyIf { skip.tests }` gate, which ANDed with the old gate to the
+	// confusing "run only if you both name `test` AND pass -Dskip.tests=true". `skip.tests` now means what its
+	// name says. NOTE: this is the SINGLE gate — do not add a second `onlyIf` in consumer builds (they AND, and
+	// only `setOnlyIf` replaces). Publish steps stay green via `-x test`. See bundle
+	// spec/P3-coherent-test-gate-design-2026-07-06.md.
+    onlyIf { !Boolean.getBoolean('skip.tests') }
 }
 
 if (project.tasks.findByName('jacocoTestReport')) {

--- a/gradle/tagit.gradle
+++ b/gradle/tagit.gradle
@@ -6,6 +6,17 @@ apply plugin: "project-report"
 // apply from: "https://raw.githubusercontent.com/tagitmobile/tagit-core-gradle/${tagitGradleVersion}/gradle/spotless/style.gradle"
 apply from: "https://raw.githubusercontent.com/tagitmobile/tagit-core-gradle/${tagitGradleVersion}/gradle/tagit-sonar.gradle"
 
+// [rj.added 2026-07-06] Belt-and-suspenders: enable the JUnit Platform (JUnit 5/6, Jupiter) engine here too.
+// tagit-sonar.gradle (applied above) already calls useJUnitPlatform(), but vendored/local copies of THIS script
+// have drifted in the past and dropped the sonar apply (see tagit-core commit 584f2f7), leaving Gradle to fall
+// back to the JUnit 4 engine and discover ZERO Jupiter tests ("test sources present ... did not discover any
+// tests"). Re-declaring it directly on tagit.gradle is idempotent with sonar and makes Jupiter discovery
+// survive that drift for every consumer. This does NOT set an onlyIf gate — the gate stays owned by
+// tagit-sonar.gradle so the two do not compound (see the mx78 platform-promotions spec, Promotion 3).
+tasks.withType(Test).configureEach {
+	useJUnitPlatform()
+}
+
 repositories {
   // [rj.added 2024.03.23] added support for cloud instances			
 	if (null != System.properties['partner-cloud']) {


### PR DESCRIPTION
Platform promotions surfaced by the downstream **mx78 uplift** of MRB + the 9 MDB connectors to the 7.8 line (SB 4.1 / SF7 / JDK 25 / Gradle 9.5.1). Fixes that belong in the shared Gradle scripts so every Mobeix product inherits them.

### P1 — `tagit.gradle`: belt-and-suspenders `useJUnitPlatform()`
`tagit-sonar.gradle` (applied by `tagit.gradle`) already sets it, but **vendored/local copies of `tagit.gradle` have drifted** and dropped the sonar apply (cf. tagit-core `584f2f7`), leaving Gradle on the JUnit 4 engine → **zero Jupiter tests discovered**. Re-declaring it directly on `tagit.gradle` is idempotent and survives that drift. Deliberately **no `onlyIf`** here so it doesn't compound the gate that `tagit-sonar.gradle` owns.

### P2 — `tagit-angular.gradle`: node-gradle 7.x fail-fast guard
The 7.x `node{}` DSL (`nodeProjectDir`, yarn removed) is now required on the Gradle 9 line. node-gradle < 7.x (old default 2.2.4) uses `Project.exec()` removed in Gradle 9 → confusing `npmSetup` failure. Guard detects the 7.x DSL via the exception-safe `hasProperty('nodeProjectDir')` and fails **only on definitive old-plugin detection** (never breaks a valid 7.x build), pointing to `nodeGradleVersion >= 7.1.0`.

### P3 — `tagit-sonar.gradle`: single coherent test gate (Option A)
Replaces the two-gate setup — sonar `taskNames.contains('test')` **AND** the per-consumer inverted `test.onlyIf { skip.tests }` — which ANDed into the confusing "run only if you both name `test` **and** pass `-Dskip.tests=true`". Now a single gate: `onlyIf { !Boolean.getBoolean('skip.tests') }` — **tests run by default; `-Dskip.tests=true` skips**. The inverted consumer gates are removed in `tagit-core` / `tagit-core-sample` (separate MRs on their line branch).

**Validated:** `tagit-core-sample` mapper suite ran 21 tests (previously silently skipped) with **zero `NoSuchBeanDefinitionException`** (SF7 dispatch intact) under the new no-`-Dskip.tests` recipe.

Specs (bundle): `platform-promotions-from-mx78-uplift-2026-07-06.md`, `P3-coherent-test-gate-design-2026-07-06.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)